### PR TITLE
maintenance: rrddump pointing at incorrect repo

### DIFF
--- a/rrddump.opam
+++ b/rrddump.opam
@@ -3,9 +3,9 @@
 opam-version: "2.0"
 maintainer: "xen-api@lists.xen.org"
 authors: ["John Else"]
-homepage: "https://github.com/xapi-project/xcp-rrd"
-bug-reports: "https://github.com/xapi-project/xcp-rrd/issues"
-dev-repo: "git+https://github.com/xapi-project/xcp-rrd.git"
+homepage: "https://github.com/xapi-project/rrddump"
+bug-reports: "https://github.com/xapi-project/rrddump/issues"
+dev-repo: "git+https://github.com/xapi-project/rrddump.git"
 tags: [
   "org:xapi-project"
 ]


### PR DESCRIPTION
pair with xs-opam PR: https://github.com/xapi-project/xs-opam/pull/441